### PR TITLE
Removed sourceMappingURL comment from UglifyJS output

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ UglifyJSOptimizer.prototype.optimize = function(args, callback) {
       data: optimized.code,
       map: optimized.map
     } : {data: optimized.code};
+    result.data = result.data.replace(/\n\/\/# sourceMappingURL=\S+$/, '');
     callback(null, result);
   }
 };


### PR DESCRIPTION
At some point in the last year, UglifyJS started appending a sourceMappingURL comment to its output. We don't want it to do this, Brunch already adds one with the correct URL.

There's no way to have UglifyJS generate the source map but not add the comment, so I strip the comment from the output manually.

This change also fixes the unit tests, which were failing.